### PR TITLE
Add Smithery installation instructions to run locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-![image](https://github.com/user-attachments/assets/a12ac722-dfc0-4ee4-86b4-497638f946f8)# Apple MCP tools
+![image](https://github.com/user-attachments/assets/a12ac722-dfc0-4ee4-86b4-497638f946f8)
+# Apple MCP tools
+[![smithery badge](https://smithery.ai/badge/@Dhravya/apple-mcp)](https://smithery.ai/server/@Dhravya/apple-mcp)
 
 This is a collection of apple-native tools for the [MCP protocol](https://modelcontextprotocol.com/docs/mcp-protocol).
 
@@ -58,6 +60,8 @@ You can also daisy-chain commands to create a workflow. Like:
 
 ### Installation
 
+#### Manual
+
 You just need bun, install with `brew install oven-sh/bun/bun`
 
 Now, edit your `claude_desktop_config.json` with this:
@@ -71,6 +75,14 @@ Now, edit your `claude_desktop_config.json` with this:
     }
   }
 }
+```
+
+#### Smithery
+
+To install Apple MCP for Claude Desktop automatically via [Smithery](https://smithery.ai/server/@Dhravya/apple-mcp):
+
+```bash
+npx -y @smithery/cli@latest install @Dhravya/apple-mcp --client claude
 ```
 
 Now, ask Claude to use the `apple-mcp` tool.

--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ To install Apple MCP for Claude Desktop automatically via [Smithery](https://smi
 npx -y @smithery/cli@latest install @Dhravya/apple-mcp --client claude
 ```
 
+### Usage
+
 Now, ask Claude to use the `apple-mcp` tool.
 
 ```


### PR DESCRIPTION
Hey Dhravya, Smithery author here. We set this server as non-remote in our registry, so end users can now install this and run it locally as intended. This PR adds smithery install count badge, and installation instructions. You can test it out with
```bash
npx -y @smithery/cli@latest install @Dhravya/apple-mcp --client claude
```
