### PR TITLE
feat: Add draft email functionality

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -723,6 +723,25 @@ end tell`;
 								};
 							}
 
+							case "draft": {
+								if (!args.to || !args.subject || !args.body) {
+									throw new Error(
+										"Recipient (to), subject, and body are required for draft operation",
+									);
+								}
+								const result = await mailModule.createDraft(
+									args.to,
+									args.subject,
+									args.body,
+									args.cc,
+									args.bcc,
+								);
+								return {
+									content: [{ type: "text", text: result }],
+									isError: false,
+								};
+							}
+
 							case "mailboxes": {
 								if (args.account) {
 									const mailboxes = await mailModule.getMailboxesForAccount(
@@ -1425,7 +1444,7 @@ function isMessagesArgs(args: unknown): args is {
 }
 
 function isMailArgs(args: unknown): args is {
-	operation: "unread" | "search" | "send" | "mailboxes" | "accounts" | "latest";
+	operation: "unread" | "search" | "send" | "draft" | "mailboxes" | "accounts" | "latest";
 	account?: string;
 	mailbox?: string;
 	limit?: number;
@@ -1466,6 +1485,7 @@ function isMailArgs(args: unknown): args is {
 			if (!searchTerm || typeof searchTerm !== "string") return false;
 			break;
 		case "send":
+		case "draft":
 			if (
 				!to ||
 				typeof to !== "string" ||

--- a/utils/mail.ts
+++ b/utils/mail.ts
@@ -333,6 +333,86 @@ end tell`;
 }
 
 /**
+ * Create a draft email (NEW FEATURE)
+ */
+async function createDraft(
+	to: string,
+	subject: string,
+	body: string,
+	cc?: string,
+	bcc?: string,
+): Promise<string | undefined> {
+	try {
+		const accessResult = await requestMailAccess();
+		if (!accessResult.hasAccess) {
+			throw new Error(accessResult.message);
+		}
+
+		// Validate inputs
+		if (!to || !to.trim()) {
+			throw new Error("To address is required");
+		}
+		if (!subject || !subject.trim()) {
+			throw new Error("Subject is required");
+		}
+		if (!body || !body.trim()) {
+			throw new Error("Email body is required");
+		}
+
+		// Use file-based approach for email body to avoid AppleScript escaping issues
+		const tmpFile = `/tmp/email-body-${Date.now()}.txt`;
+		const fs = require("fs");
+
+		// Write content to temporary file
+		fs.writeFileSync(tmpFile, body.trim(), "utf8");
+
+		const script = `
+tell application "Mail"
+    activate
+
+    -- Read email body from file to preserve formatting
+    set emailBody to read file POSIX file "${tmpFile}" as «class utf8»
+
+    -- Create new message as DRAFT (visible:true opens compose window)
+    set newMessage to make new outgoing message with properties {subject:"${subject.replace(/"/g, '\\"')}", content:emailBody, visible:true}
+
+    tell newMessage
+        make new to recipient with properties {address:"${to.replace(/"/g, '\\"')}"}
+        ${cc ? `make new cc recipient with properties {address:"${cc.replace(/"/g, '\\"')}"}` : ""}
+        ${bcc ? `make new bcc recipient with properties {address:"${bcc.replace(/"/g, '\\"')}"}` : ""}
+    end tell
+
+    -- Do NOT send - this creates a draft that opens for editing
+    -- send newMessage  <-- Commented out for draft creation
+    
+    return "DRAFT_CREATED"
+end tell`;
+
+		const result = (await runAppleScript(script)) as string;
+
+		// Clean up temporary file
+		try {
+			fs.unlinkSync(tmpFile);
+		} catch (e) {
+			// Ignore cleanup errors
+		}
+
+		if (result === "DRAFT_CREATED") {
+			return `Draft email created for ${to} with subject "${subject}". The compose window is now open for editing.`;
+		} else {
+			throw new Error("Failed to create draft email");
+		}
+	} catch (error) {
+		console.error(
+			`Error creating draft email: ${error instanceof Error ? error.message : String(error)}`,
+		);
+		throw new Error(
+			`Error creating draft email: ${error instanceof Error ? error.message : String(error)}`,
+		);
+	}
+}
+
+/**
  * Get list of mailboxes (simplified for performance)
  */
 async function getMailboxes(): Promise<string[]> {
@@ -585,6 +665,7 @@ export default {
 	getUnreadMails,
 	searchMails,
 	sendMail,
+	createDraft,  // NEW: Draft email functionality
 	getMailboxes,
 	getAccounts,
 	getMailboxesForAccount,


### PR DESCRIPTION
## Summary
This PR adds draft email functionality to the Apple MCP, allowing users to create draft emails for editing before sending.

## Changes Made
- ✅ **New `createDraft` function** - Creates draft emails without immediate sending
- ✅ **Opens Mail app compose window** - Users can edit, add attachments, and send manually
- ✅ **Same interface as `sendMail`** - Supports to, cc, bcc recipients
- ✅ **Proper validation** - Input validation and error handling
- ✅ **Export updated** - Function available in default export

## Implementation Details
The `createDraft` function:
- Uses the same AppleScript approach as `sendMail`
- Creates a new outgoing message with recipients and content
- Sets `visible:true` to open the compose window
- **Crucially omits** the `send newMessage` command to create a draft
- Provides user feedback about draft creation

## Usage Example
```javascript
// Create a draft email
await createDraft(
    "colleague@company.com", 
    "Project Update", 
    "Hi,\n\nHere's the latest update...\n\nBest regards",
    "manager@company.com",  // cc
    "archive@company.com"   // bcc
);
// Result: Draft opens in Mail app for editing
```

## Benefits
- **User control** - Review and edit before sending
- **Attachment support** - Add files in Mail app
- **Rich formatting** - Use Mail app's formatting tools
- **Error prevention** - Reduces accidental sends
- **Workflow integration** - Fits existing email habits

## Testing
- ✅ Successfully creates draft emails
- ✅ Opens compose window with proper recipients
- ✅ Handles cc/bcc correctly
- ✅ Validates inputs properly
- ✅ Maintains backward compatibility

## Backward Compatibility
This change is fully backward compatible - existing `sendMail` functionality remains unchanged.

---

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>